### PR TITLE
.nuspec extended with .props for easier MSBuild integration.

### DIFF
--- a/Tools.InnoSetup.nuspec
+++ b/Tools.InnoSetup.nuspec
@@ -31,6 +31,8 @@ following:
         <file src="license.txt" target="" />
         <file src="readme.txt" target="" />
 
+        <file src="Tools.InnoSetup.props" target="build" />
+
         <file src="c:\Program Files (x86)\Inno Setup 6\Default.isl" target="tools" />
         <file src="c:\Program Files (x86)\Inno Setup 6\isbunzip.dll" target="tools" />
         <file src="c:\Program Files (x86)\Inno Setup 6\isbzip.dll" target="tools" />

--- a/Tools.InnoSetup.props
+++ b/Tools.InnoSetup.props
@@ -2,5 +2,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <InnoSetupDir>$(MSBuildThisFileDirectory)..\tools\</InnoSetupDir>
+    <InnoSetupCompiler>$(MSBuildThisFileDirectory)..\tools\ISCC.exe</InnoSetupCompiler>
   </PropertyGroup>
 </Project>

--- a/Tools.InnoSetup.props
+++ b/Tools.InnoSetup.props
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <InnoSetupDir>$(MSBuildThisFileDirectory)..\tools\</InnoSetupDir>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
NuGet will install the `Tools.InnoSetup.props` into the project which references the `Tools.InnoSetup` NuGet package. Which will in turn provide the properties `$(InnoSetupDir)` and `$(InnoSetupCompiler)`.

`$(InnoSetupDir)` points to the tools directory of the installed package and `$(InnoSetupCompiler)` points directly at the `ISCC.exe`. Now one can use something like `<Exec Command="$(InnoSetupDir)ISCC.exe someSetup.iss"/>` or even simpler `<Exec Command="$(InnoSetupCompiler) someSetup.iss"/>` in MSBuild.