### PR TITLE
update to 6.0.5-dev

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,7 +1,7 @@
 name: Build NuGet package
 
 env:
-  INNO_VERSION: 6.0.4
+  INNO_VERSION: 6.0.5-dev
 
 on: [push, pull_request]
 

--- a/Tools.InnoSetup.nuspec
+++ b/Tools.InnoSetup.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Tools.InnoSetup</id>
-        <version>6.0.4</version>
+        <version>6.0.5-dev</version>
         <title>Inno Setup tools</title>
         <authors>Vaclav Slavik, Jordan Russell</authors>
         <license type="file">license.txt</license>


### PR DESCRIPTION
* Link to dev version was provided in official Inno Setup Google Groups, see https://groups.google.com/d/msg/innosetup/IgoRx-i2LeU/YT8ONUG3AAAJ.
* the resulting NuGet package will be published as a pre-release version, because of the _-dev_ version suffix (see https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#pre-release-versions)