### PR TITLE
Add dotnet tool support

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -26,8 +26,12 @@ jobs:
     - name: List installed files
       run: gci inst -Recurse -File
 
+    - name: Set InnoSetup Version in C#
+      run: echo ^"${{ env.INNO_VERSION }}^";} >> ./dotnet-tool/InnoSetupVersion.cs
+      shell: cmd
+
     - name: Build NuGet package
-      run: nuget pack Tools.InnoSetup.nuspec -Verbosity detailed
+      run: dotnet pack ./dotnet-tool/Tools.InnoSetup.csproj -verbosity:detailed /p:Configuration=Release
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.nupkg
+inst/
+bin/
+obj/

--- a/README.md
+++ b/README.md
@@ -20,8 +20,15 @@ following:
 How to install
 --------------
 
+Nuget:
 ```
 dotnet add package Tools.InnoSetup
+```
+
+Dotnet Tool:
+```
+dotnet tool install Tools.InnoSetup
+GetISCCPath
 ```
 
 

--- a/Tools.InnoSetup.nuspec
+++ b/Tools.InnoSetup.nuspec
@@ -11,23 +11,27 @@
         <summary>Inno Setup tools packaged for NuGet.</summary>
         <description>Inno Setup tools packaged for NuGet.
 
-This is an unofficial package of the Inno Setup installer, intended for use as
-a NuGet dependency.
+            This is an unofficial package of the Inno Setup installer, intended for use as
+            a NuGet dependency.
 
-This package is kept up to date and with upstream IS releases and includes the
-following:
+            This package is kept up to date and with upstream IS releases and includes the
+            following:
 
- - Unicode build of Inno Setup
- - Inno Setup Preprocessor
- - encryption support
- - official translations of Inno Setup
+            - Unicode build of Inno Setup
+            - Inno Setup Preprocessor
+            - encryption support
+            - official translations of Inno Setup
         </description>
         <copyright>Jordan Russell {http://www.jrsoftware.org/}</copyright>
         <language>en-US</language>
         <tags>installer inno innosetup</tags>
+        <packageTypes>
+            <packageType name="DotnetTool" />
+        </packageTypes>
     </metadata>
 
     <files>
+        <file src="dotnet-tool\bin\Release\net6.0\publish\**" target="tools\net6.0\any" />
         <file src="license.txt" target="" />
         <file src="README.md" target="" />
         <file src="Tools.InnoSetup.props" target="build" />

--- a/dotnet-tool/DotnetToolSettings.xml
+++ b/dotnet-tool/DotnetToolSettings.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DotNetCliTool Version="1">
+  <Commands>
+    <Command Name="GetISCCPath" EntryPoint="Tools.InnoSetup.dll" Runner="dotnet" />
+  </Commands>
+</DotNetCliTool>

--- a/dotnet-tool/InnoSetupVersion.cs
+++ b/dotnet-tool/InnoSetupVersion.cs
@@ -1,0 +1,6 @@
+namespace Tools.InnoSetup;
+
+internal static class Versions
+{
+    // This class gets completed via github workflow
+    public const string InnoSetup =

--- a/dotnet-tool/Program.cs
+++ b/dotnet-tool/Program.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Tools.InnoSetup;
+internal class Program
+{
+    static void Main()
+    {
+        using var currentProcess = Process.GetCurrentProcess();
+        var dir = Path.GetDirectoryName(currentProcess.MainModule.FileName);
+        var iscc = $".store/tools.innosetup/{Versions.InnoSetup}/tools.innosetup/{Versions.InnoSetup}/tools/ISCC.exe";
+        var fullPath = Path.Combine(dir, iscc);
+        if (File.Exists(fullPath))
+        {
+            Console.WriteLine(fullPath);
+        }
+        else
+        {
+            throw new Exception($"Could not find: {fullPath}");
+        }
+    }
+}

--- a/dotnet-tool/Tools.InnoSetup.csproj
+++ b/dotnet-tool/Tools.InnoSetup.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+        <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
+        <PackageOutputPath>../</PackageOutputPath>
+        <NuspecFile>../Tools.InnoSetup.nuspec</NuspecFile>
+        <NoDefaultExcludes>true</NoDefaultExcludes>
+        <PackAsTool>true</PackAsTool>
+        <LangVersion>10.0</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Update="DotnetToolSettings.xml" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+</Project>
+  


### PR DESCRIPTION
This allows the package to be installed via `dotnet tool`

It registers the command `GetISCCPath`, which will return the path to `iscc.exe`