### PR TITLE
Add dotnet tool support

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -29,12 +29,14 @@ jobs:
     - name: Build NuGet package
       run: nuget pack Tools.InnoSetup.nuspec -Verbosity detailed
 
+    - name: Build Dotnet Tool package
+      run: dotnet pack ./dotnet-tool/Tools.InnoSetup.Cli.csproj -verbosity:detailed /p:Configuration=Release /p:Version=${{ env.INNO_VERSION }}
+
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
         name: nuget-package
         path: "*.nupkg"
-
 
   publish:
     name: Publish release to NuGet

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.nupkg
+inst/
+bin/
+obj/
+FileContentIndex

--- a/README.md
+++ b/README.md
@@ -20,8 +20,15 @@ following:
 How to install
 --------------
 
+Nuget:
 ```
 dotnet add package Tools.InnoSetup
+```
+
+Dotnet Tool:
+```
+dotnet tool install Tools.InnoSetup.Cli
+GetISCCPath
 ```
 
 

--- a/Tools.InnoSetup.Cli.nuspec
+++ b/Tools.InnoSetup.Cli.nuspec
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>Tools.InnoSetup.Cli</id>
+        <version>$version$</version>
+        <title>Inno Setup with dotnet tool support</title>
+        <authors>Vaclav Slavik, Jordan Russell</authors>
+        <license type="file">license.txt</license>
+        <projectUrl>https://github.com/vslavik/nuget-tools-innosetup</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <summary>Inno Setup tools packaged for NuGet.</summary>
+        <description>Inno Setup tools packaged for NuGet.
+
+            This is an unofficial package of the Inno Setup installer, intended for use as
+            a NuGet dependency.
+
+            This package is kept up to date and with upstream IS releases and includes the
+            following:
+
+            - Unicode build of Inno Setup
+            - Inno Setup Preprocessor
+            - encryption support
+            - official translations of Inno Setup
+        </description>
+        <copyright>Jordan Russell {http://www.jrsoftware.org/}</copyright>
+        <language>en-US</language>
+        <tags>installer inno innosetup</tags>
+        <packageTypes>
+            <packageType name="DotnetTool" />
+        </packageTypes>
+    </metadata>
+
+    <files>
+        <file src="dotnet-tool\bin\Release\net6.0\publish\**" target="tools\net6.0\any" />
+        <file src="license.txt" target="" />
+        <file src="README.md" target="" />
+        <file src="inst\*.*" exclude="unins000.*" target="tools\InnoSetup" />
+        <file src="inst\Languages\*.isl" target="tools\InnoSetup\Languages" />
+    </files>
+</package>

--- a/Tools.InnoSetup.Cli.nuspec
+++ b/Tools.InnoSetup.Cli.nuspec
@@ -34,7 +34,6 @@
         <file src="dotnet-tool\bin\Release\net6.0\publish\**" target="tools\net6.0\any" />
         <file src="license.txt" target="" />
         <file src="README.md" target="" />
-        <file src="inst\*.*" exclude="unins000.*" target="tools\InnoSetup" />
-        <file src="inst\Languages\*.isl" target="tools\InnoSetup\Languages" />
+        <file src="inst\**" exclude="inst\unins000.*;inst\Examples\**" target="tools\InnoSetup" />
     </files>
 </package>

--- a/Tools.InnoSetup.nuspec
+++ b/Tools.InnoSetup.nuspec
@@ -11,16 +11,16 @@
         <summary>Inno Setup tools packaged for NuGet.</summary>
         <description>Inno Setup tools packaged for NuGet.
 
-This is an unofficial package of the Inno Setup installer, intended for use as
-a NuGet dependency.
+            This is an unofficial package of the Inno Setup installer, intended for use as
+            a NuGet dependency.
 
-This package is kept up to date and with upstream IS releases and includes the
-following:
+            This package is kept up to date and with upstream IS releases and includes the
+            following:
 
- - Unicode build of Inno Setup
- - Inno Setup Preprocessor
- - encryption support
- - official translations of Inno Setup
+            - Unicode build of Inno Setup
+            - Inno Setup Preprocessor
+            - encryption support
+            - official translations of Inno Setup
         </description>
         <copyright>Jordan Russell {http://www.jrsoftware.org/}</copyright>
         <language>en-US</language>
@@ -31,7 +31,6 @@ following:
         <file src="license.txt" target="" />
         <file src="README.md" target="" />
         <file src="Tools.InnoSetup.props" target="build" />
-        <file src="inst\*.*" exclude="unins000.*" target="tools" />
-        <file src="inst\Languages\*.isl" target="tools\Languages" />
+        <file src="inst\**" exclude="inst\unins000.*;inst\Examples\**" target="tools" />
     </files>
 </package>

--- a/dotnet-tool/DotnetToolSettings.xml
+++ b/dotnet-tool/DotnetToolSettings.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DotNetCliTool Version="1">
+  <Commands>
+    <Command Name="GetISCCPath" EntryPoint="Tools.InnoSetup.Cli.dll" Runner="dotnet" />
+  </Commands>
+</DotNetCliTool>

--- a/dotnet-tool/Program.cs
+++ b/dotnet-tool/Program.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace Tools.InnoSetup.Cli;
+internal class Program
+{
+    static void Main()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+
+        var dir = Path.GetDirectoryName(assembly.Location);
+        var iscc = $"../../InnoSetup/ISCC.exe";
+        var fullPath = Path.GetFullPath(Path.Combine(dir, iscc));
+        if (File.Exists(fullPath))
+        {
+            Console.WriteLine(fullPath);
+        }
+        else
+        {
+            throw new Exception($"Could not find: {fullPath}");
+        }
+    }
+}

--- a/dotnet-tool/Tools.InnoSetup.Cli.csproj
+++ b/dotnet-tool/Tools.InnoSetup.Cli.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
+        <PackageOutputPath>../</PackageOutputPath>
+        <NuspecFile>../Tools.InnoSetup.Cli.nuspec</NuspecFile>
+        <PackAsTool>true</PackAsTool>
+        <LangVersion>10.0</LangVersion>
+        <NuspecProperties>version=$(Version)</NuspecProperties>
+    </PropertyGroup>
+
+    <!-- For some reason include a NuspecFile breaks DotnetToolSettings.xml generation, so add this
+    file manually -->
+    <ItemGroup>
+        <None Update="DotnetToolSettings.xml" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+</Project>
+  


### PR DESCRIPTION
This adds a new package `Tools.InnoSetup.Cli` which supports `dotnet tool install`

I choose to do it as a new package, because it adds a dependency onto `net6`